### PR TITLE
DX: Add composer keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,12 @@
     "name": "redaxo/php-cs-fixer-config",
     "description": "php-cs-fixer config for REDAXO",
     "type": "library",
+    "keywords": [
+        "fixer",
+        "standards",
+        "static analysis",
+        "static code analysis"
+    ],
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
as per https://github.com/composer/composer/pull/10960 this allows composer to warn the user, when installing the tool as a project dependency instead of a dev-dependency