### PR TITLE
Lock php-cs-fixer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": "^8.1",
-        "friendsofphp/php-cs-fixer": "^3.51.0",
-        "kubawerlos/php-cs-fixer-custom-fixers": "^3.21.0"
+        "friendsofphp/php-cs-fixer": "3.51.0",
+        "kubawerlos/php-cs-fixer-custom-fixers": "3.21.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Da neue Versionen CS-Änderungen zur Folge haben können, sollte hier im Repo immer zentral zunächst geprüft werden, ob Config-Änderungen notwendig sind.