### PR TITLE
Pin GitHub Action digests to full semver in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "config:best-practices",
+        "helpers:pinGitHubActionDigestsToSemver",
         ":timezone(Europe/Berlin)",
         ":disableDependencyDashboard",
         ":semanticCommitsDisabled"


### PR DESCRIPTION
## Summary
- Add `helpers:pinGitHubActionDigestsToSemver` preset so Renovate writes the full version (e.g. `# v4.1.7`) as comment behind the pinned SHA instead of just the major (e.g. `# v4`).

## Test plan
- [ ] Next Renovate run produces PRs with full semver comments behind action SHAs