### PR TITLE
Upstream-Check: resolve php-cs-fixer-config from git instead of packagist

### DIFF
--- a/.github/workflows/upstream-check.yml
+++ b/.github/workflows/upstream-check.yml
@@ -15,6 +15,10 @@ jobs:
             group: upstream-check-${{github.event_name}}-${{ matrix.repo }}-${{ matrix.branch }}-${{ github.head_ref || github.run_id }}
             cancel-in-progress: true
 
+        env:
+            # authenticate the GitHub API calls of composer's VCS driver (see below) against the rate limit
+            COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ github.token }}"}}'
+
         strategy:
             fail-fast: false
             matrix:
@@ -42,6 +46,12 @@ jobs:
                     php-version: ${{ matrix.php }}
                     coverage: none
 
+            # Packagist does not create dev versions for bot branches (renovate/*, dependabot/*, ...) anymore,
+            # see https://github.com/composer/packagist/pull/1783. Resolving the package straight from git
+            # makes every branch requirable again, including the head branch of renovate PRs.
+            -   name: Resolve redaxo/php-cs-fixer-config from git instead of packagist
+                run: composer config repositories.redaxo-php-cs-fixer-config vcs https://github.com/redaxo/php-cs-fixer-config --no-interaction --ansi
+
             -   name: Set redaxo/php-cs-fixer-config to main branch
                 run: composer require redaxo/php-cs-fixer-config:dev-main friendsofphp/php-cs-fixer:\* --dev --no-scripts --no-interaction --no-update --ansi
 
@@ -54,7 +64,9 @@ jobs:
                 run: vendor/bin/php-cs-fixer fix -v --ansi --diff || exit 0
 
             -   name: Set redaxo/php-cs-fixer-config to current branch
-                run: composer require redaxo/php-cs-fixer-config:dev-${{ github.head_ref }} --dev --with-all-dependencies --no-scripts --no-interaction --no-progress --ansi
+                env:
+                    HEAD_REF: ${{ github.head_ref }}
+                run: composer require "redaxo/php-cs-fixer-config:dev-$HEAD_REF" --dev --with-all-dependencies --no-scripts --no-interaction --no-progress --ansi
 
             -   name: Run php-cs-fixer
                 run: vendor/bin/php-cs-fixer check -v --ansi --diff || echo "::warning file=src/Config.php::New changes in ${{ matrix.repo }}@${{ matrix.branch }}."


### PR DESCRIPTION
## Problem

Der Upstream-Check schlägt seit dem 10.07. in allen Renovate-PRs fehl:

```
Root composer.json requires redaxo/php-cs-fixer-config dev-renovate/actions,
found redaxo/php-cs-fixer-config[dev-main, 1.0.0, ..., 3.1.1] but it does not match the constraint.
```

Ursache ist keine Änderung in diesem Repo (letzter Commit davor war vom 1. Juni), sondern composer/packagist#1783 („Avoid importing well-known transient branches", gemergt am 08.07.). Packagist legt seitdem keine dev-Versionen mehr für Branches mit Bot-Präfix an:

```php
{^dev-(gh-readonly-queue/|renovate/|dependabot/|conductor-|merge-up/).+}
```

Da der Skip vor dem `unset($existingVersions[...])` sitzt, galten die bereits importierten `dev-renovate/*`-Versionen zusätzlich als „upstream verschwunden" und wurden nach einem Tag Gnadenfrist hart gelöscht — daher der Verzug von zwei Tagen zwischen Merge und erstem roten Run.

Betroffen sind ausschließlich Branches mit diesen Präfixen; eigene Branches wie `php85` matchen nicht und liefen weiter durch. Bei uns sind es halt zufällig alle offenen PRs.

## Lösung

Das Paket wird als VCS-Repository eingebunden, dann liest Composer die verfügbaren Versionen direkt aus Git — dort gibt es die Blocklist nicht und jeder Branch ist wieder requirable.

* `COMPOSER_AUTH` mit `github.token`, damit die API-Calls des VCS-Drivers nicht ins Rate-Limit von 60/h pro Runner-IP laufen.
* `github.head_ref` wird nicht mehr in den Shell-Befehl interpoliert, sondern per Env-Var übergeben.

## Test

Kompletter Ablauf lokal mit `redaxo/redaxo@5.x` nachgespielt:

```
- Locking redaxo/php-cs-fixer-config (dev-main e7d82e6)
- Upgrading redaxo/php-cs-fixer-config (dev-main e7d82e6 => dev-renovate/actions 25e7fca)
Loaded config REDAXO 5 ... Found 0 of 578 files that can be fixed
```

## Hinweis zum Rollout

Bei `pull_request`-Events nimmt GitHub die Workflow-Datei aus dem PR-Branch. Die drei offenen Renovate-PRs bleiben also rot, bis sie auf den neuen main rebased werden.