### PR TITLE
Renovate: group action major updates with minor updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,7 @@
         {
             "matchManagers": ["github-actions"],
             "groupName": "actions",
+            "separateMajorMinor": false,
             "schedule": ["on the first day of the month"]
         }
     ]


### PR DESCRIPTION
`config:best-practices` (via `config:recommended`) keeps the default `separateMajorMinor: true`, so major updates of GitHub Actions were split off into their own PR despite the `actions` group.

With `separateMajorMinor: false` all action updates — digest bumps, minors and majors — land in a single monthly "Update actions" PR.